### PR TITLE
Fix callbacks on iOS and Android

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -46,6 +46,7 @@ export class TNSPlayer implements TNSPlayerI {
           this.player.setOnErrorListener(new MediaPlayer.OnErrorListener({
             onError: (mp: any, what: number, extra: number) => {
               options.errorCallback();
+              return true;
             }
           }));
         }
@@ -55,6 +56,7 @@ export class TNSPlayer implements TNSPlayerI {
           this.player.setOnInfoListener(new MediaPlayer.OnInfoListener({
             onInfo: (mp: any, what: number, extra: number) => {
               options.infoCallback();
+              return true;
             }
           }))
         }
@@ -98,6 +100,7 @@ export class TNSPlayer implements TNSPlayerI {
           this.player.setOnErrorListener(new MediaPlayer.OnErrorListener({
             onError: (mp: any, what: number, extra: number) => {
               options.errorCallback();
+              return true;
             }
           }));
         }
@@ -107,6 +110,7 @@ export class TNSPlayer implements TNSPlayerI {
           this.player.setOnInfoListener(new MediaPlayer.OnInfoListener({
             onInfo: (mp: any, what: number, extra: number) => {
               options.infoCallback();
+              return true;
             }
           }))
         }

--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -33,25 +33,31 @@ export class TNSPlayer implements TNSPlayerI {
         this.player.prepareAsync();
 
         // On Complete
-        this.player.setOnCompletionListener(new MediaPlayer.OnCompletionListener({
-          onCompletion: (mp) => {
-            options.completeCallback();
-          }
-        }));
+        if (options.completeCallback) {
+          this.player.setOnCompletionListener(new MediaPlayer.OnCompletionListener({
+            onCompletion: (mp) => {
+              options.completeCallback();
+            }
+          }));
+        }
 
         // On Error
-        this.player.setOnErrorListener(new MediaPlayer.OnErrorListener({
-          onError: (mp: any, what: number, extra: number) => {
-            options.errorCallback();
-          }
-        }));
+        if (options.errorCallback) {
+          this.player.setOnErrorListener(new MediaPlayer.OnErrorListener({
+            onError: (mp: any, what: number, extra: number) => {
+              options.errorCallback();
+            }
+          }));
+        }
 
         // On Info
-        this.player.setOnInfoListener(new MediaPlayer.OnInfoListener({
-          onInfo: (mp: any, what: number, extra: number) => {
-            options.infoCallback();
-          }
-        }))
+        if (options.infoCallback) {
+          this.player.setOnInfoListener(new MediaPlayer.OnInfoListener({
+            onInfo: (mp: any, what: number, extra: number) => {
+              options.infoCallback();
+            }
+          }))
+        }
 
         // On Prepared
         this.player.setOnPreparedListener(new MediaPlayer.OnPreparedListener({


### PR DESCRIPTION
* Implement completion and error callbacks on iOS. There is no good equivalent of info callbacks on iOS, so that callback is never called on iOS in this implementation. 
* Ensure that callbacks are optional on Android (as documented). This was causing a crash.
* Keep error and info callbacks from causing a crash due to incorrect return value. This was causing a crash.