### PR TITLE
Allow playing from absolute paths in playFromFile on Android.

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -25,6 +25,9 @@ export class TNSPlayer implements TNSPlayerI {
           console.log('fileName: ' + fileName);
           audioPath = fileName;
         }
+        else {
+          audioPath = fileName;
+        }
 
         this.player = new MediaPlayer();
           


### PR DESCRIPTION
Quick and easy, use the passed in file name verbatim if it isn't relative to ~/. 