### PR TITLE
Add iOS Recording Functionality To Get Volume Levels

### DIFF
--- a/src/ios/recorder.ts
+++ b/src/ios/recorder.ts
@@ -8,7 +8,7 @@ export class TNSRecorder extends NSObject implements TNSRecordI {
   public static ObjCProtocols = [AVAudioRecorderDelegate];
   private _recorder: any;
   private _recordingSession: any;
-  
+
   public static CAN_RECORD(): boolean {
     return true;
   }
@@ -27,12 +27,12 @@ export class TNSRecorder extends NSObject implements TNSRecordI {
         this._recordingSession.requestRecordPermission((allowed: boolean) => {
           if (allowed) {
 
-            var recordSetting = new NSMutableDictionary([NSNumber.numberWithInt(kAudioFormatMPEG4AAC), NSNumber.numberWithInt(AVAudioQuality.Medium.rawValue), NSNumber.numberWithFloat(16000.0), NSNumber.numberWithInt(1)], 
-              ["AVFormatIDKey", "AVEncoderAudioQualityKey", "AVSampleRateKey", "AVNumberOfChannelsKey"]);    
+            var recordSetting = new NSMutableDictionary([NSNumber.numberWithInt(kAudioFormatMPEG4AAC), NSNumber.numberWithInt(AVAudioQuality.Medium.rawValue), NSNumber.numberWithFloat(16000.0), NSNumber.numberWithInt(1)],
+                ["AVFormatIDKey", "AVEncoderAudioQualityKey", "AVSampleRateKey", "AVNumberOfChannelsKey"]);
 
             errorRef = new interop.Reference();
 
-            let url = NSURL.fileURLWithPath(options.filename);     
+            let url = NSURL.fileURLWithPath(options.filename);
 
             this._recorder = AVAudioRecorder.alloc().initWithURLSettingsError(url, recordSetting, errorRef);
             if (errorRef && errorRef.value) {
@@ -58,6 +58,7 @@ export class TNSRecorder extends NSObject implements TNSRecordI {
         this._recorder.stop();
         // may need this in future
         // this._recordingSession.setActiveError(false, null);
+        _this._recorder.meteringEnabled = false;
         resolve();
       } catch (ex) {
         reject(ex);
@@ -69,6 +70,7 @@ export class TNSRecorder extends NSObject implements TNSRecordI {
     return new Promise((resolve, reject) => {
       try {
         this._recorder.stop();
+        this._recorder.meteringEnabled = false;
         this._recordingSession.setActiveError(false, null);
         this._recorder.release();
         this._recorder = undefined;
@@ -79,7 +81,22 @@ export class TNSRecorder extends NSObject implements TNSRecordI {
     });
   }
 
+  public isRecording() {
+    var _this = this;
+    return _this._recorder.recording;
+  }
+
+  public getMeters(channel: number) {
+    var _this = this;
+    if(!_this._recorder.meteringEnabled) {
+      _this._recorder.meteringEnabled = true;
+    }
+    _this._recorder.updateMeters();
+    return _this._recorder.averagePowerForChannel(channel);
+  }
+
+
   public audioRecorderDidFinishRecording(recorder: any, success: boolean) {
     console.log(`audioRecorderDidFinishRecording: ${success}`);
-  }  
+  }
 }


### PR DESCRIPTION
I’ve added two iOS functions that help a user detect what’s happening
with sound in real time.

isRecording is simple enough, returns true or false

getMeters will return the current level of volume being recorded in dB