### PR TITLE
Update package.json to allow webpack bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-audio",
   "version": "2.1.3",
   "description": "NativeScript plugin to record and play audio.",
-  "main": "audio.js",
+  "main": "audio",
   "typings": "index.d.ts",
   "nativescript": {
     "platforms": {


### PR DESCRIPTION
We released a new version of the NS webpack plugin [NS webpack plugin](https://github.com/NativeScript/nativescript-dev-webpack) today.  That change is necessary for the plugin to be compatible with it. The `.js` extension of the `main` property in the `package.json` should be removed. That way, webpack will be able to correctly reference the android or ios main file.

Check out the [Webpack article](http://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) in the NativeScript  documentation. 