### PR TITLE
NativeScript 3.0 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.js.map
 *.log
 *.d.ts
+!references.d.ts
 !index.d.ts
 !manual_typings/base.d.ts
 demo/lib

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Note: You will need to grant permissions on iOS to allow the device to access th
 ```
 
 ## Installation
+The plugin is compatible with both Nativescript 3.x and 2.x versions. Install with:
+
 `tns plugin add nativescript-audio`
+
 
 ## Sample Screen
 

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -37,11 +37,11 @@ export class AudioDemo extends Observable {
     this._SnackBar = new SnackBar();
     this.set('currentVolume', 1);
     this._slider = <Slider>page.getViewById('slider');
-    
+
     // Set player volume
     if (this._slider) {
-      this._slider.on(Observable.propertyChangeEvent, (data: any) => {
-        this.player.volume = this._slider.value/100;
+      this._slider.on("valueChange", (data: any) => {
+        this.player.volume = this._slider.value / 100;
       });
     }
   }

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,25 +1,25 @@
 {
   "nativescript": {
     "id": "org.nativescript.audio",
-    "tns-ios": {
-      "version": "2.5.0"
-    },
     "tns-android": {
-      "version": "2.5.0"
+      "version": "3.0.0"
+    },
+    "tns-ios": {
+      "version": "3.0.0"
     }
   },
   "dependencies": {
     "nativescript-audio": "file:..",
     "nativescript-snackbar": "^1.1.6",
     "nativescript-theme-core": "^1.0.2",
-    "tns-core-modules": "^2.5.1"
+    "tns-core-modules": ">=3.0.0"
   },
   "devDependencies": {
     "babel-traverse": "6.12.0",
     "babel-types": "6.11.1",
     "babylon": "6.8.4",
     "lazy": "1.0.11",
-    "nativescript-dev-typescript": "^0.3.7",
+    "nativescript-dev-typescript": "^0.4.2",
     "tns-platform-declarations": "^2.5.0",
     "typescript": "^2.1.0"
   }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -17,13 +17,21 @@
         "noImplicitUseStrict": false,
         "noFallthroughCasesInSwitch": true,
         "lib": [
-            "es2016"
+            "es6",
+            "dom"
         ],
         "typeRoots": [
             "./node_modules/@types",
             "./node_modules"
         ],
-        "types": []
+        "types": [],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "homepage": "https://github.com/bradmartin/nativescript-audio",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "tns-core-modules": "^2.5.1",
-    "tns-platform-declarations": "^2.5.0",
+    "tns-core-modules": ">=3.0.0",
+    "tns-platform-declarations": ">=3.0.0",
     "typescript": "^2.1.0"
   }
 }

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
+/// <reference path="./node_modules/tns-platform-declarations/android.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "lib": [
-            "es2016"
+            "es6",
+            "dom"
         ],
         "sourceMap": true,
         "pretty": true,
@@ -24,8 +25,14 @@
             "./node_modules/@types",
             "./node_modules"
         ],
-        "types": [
-        ]
+        "types": [],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "exclude": [
         "demo",


### PR DESCRIPTION
In this PR:
 - Plugin updated to build against `tns-core-modules@3.x.x` and `tns-platform-de
clarations@3.x.x`.
 - Demo project updated to NativeScript 3.0

_Note_: 🎉   Plugin is still compatible with NativeScript 2.x - no changes in the code 🎉  