### PR TITLE
 Audio routing to Speaker if from Receiver only 

### DIFF
--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -45,18 +45,18 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
         this._infoCallback = options.infoCallback;
         
         var audioSession = AVAudioSession.sharedInstance();
-		let output = audioSession.currentRoute.outputs.lastObject.portType;
+	let output = audioSession.currentRoute.outputs.lastObject.portType;
 		
-		if (output.match(/Receiver/)) {
-	        try {
+	if (output.match(/Receiver/)) {
+	   try {
 	          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
 	          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
 	          audioSession.setActiveError(true);
 	          //console.log("audioSession category set and active");
-	        } catch (err) {
+	    } catch (err) {
 	          //console.log("setting audioSession category failed");
-	        }
-		}
+	    }
+	}
 
         this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(NSURL.fileURLWithPath(fileName));
         this._player.delegate = this;
@@ -113,18 +113,18 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
           this._infoCallback = options.infoCallback;
           
           var audioSession = AVAudioSession.sharedInstance();
-  		  let output = audioSession.currentRoute.outputs.lastObject.portType;
+	  let output = audioSession.currentRoute.outputs.lastObject.portType;
 		
-  		  if (output.match(/Receiver/)) {
-  	        try {
-  	          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
-  	          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
-  	          audioSession.setActiveError(true);
-  	          //console.log("audioSession category set and active");
-  	        } catch (err) {
-  	          //console.log("setting audioSession category failed");
-  	        }
-  		  }
+	  if (output.match(/Receiver/)) {
+	    try {
+	          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
+	          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
+	          audioSession.setActiveError(true);
+	          //console.log("audioSession category set and active");
+	    } catch (err) {
+	          //console.log("setting audioSession category failed");
+	    }
+	  }
 
           this._player = (<any>AVAudioPlayer.alloc()).initWithDataError(data, null);
           this._player.delegate = this;

--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -113,14 +113,18 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
           this._infoCallback = options.infoCallback;
           
           var audioSession = AVAudioSession.sharedInstance();
-          try {
-            audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
-            audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
-            audioSession.setActiveError(true);
-            //console.log("audioSession category set and active");
-          } catch (err) {
-            //console.log("setting audioSession category failed");
-          }
+  		  let output = audioSession.currentRoute.outputs.lastObject.portType;
+		
+  		  if (output.match(/Receiver/)) {
+  	        try {
+  	          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
+  	          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
+  	          audioSession.setActiveError(true);
+  	          //console.log("audioSession category set and active");
+  	        } catch (err) {
+  	          //console.log("setting audioSession category failed");
+  	        }
+  		  }
 
           this._player = (<any>AVAudioPlayer.alloc()).initWithDataError(data, null);
           this._player.delegate = this;

--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -45,14 +45,18 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
         this._infoCallback = options.infoCallback;
         
         var audioSession = AVAudioSession.sharedInstance();
-        try {
-          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
-          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
-          audioSession.setActiveError(true);
-          //console.log("audioSession category set and active");
-        } catch (err) {
-          //console.log("setting audioSession category failed");
-        }
+		let output = audioSession.currentRoute.outputs.lastObject.portType;
+		
+		if (output.match(/Receiver/)) {
+	        try {
+	          audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
+	          audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverrideSpeaker);
+	          audioSession.setActiveError(true);
+	          //console.log("audioSession category set and active");
+	        } catch (err) {
+	          //console.log("setting audioSession category failed");
+	        }
+		}
 
         this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(NSURL.fileURLWithPath(fileName));
         this._player.delegate = this;


### PR DESCRIPTION
Here audio will be routed to Speaker if only the current route type is Receiver (Ear Speaker). It won't route for other types. This will be better than previous solution.